### PR TITLE
Add LANG=C for when the locale is not english

### DIFF
--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+export LANG=C 
 # check for provided arguments
 if [[ $# -lt 1 ]]; then
     echo "[!] No package name provided"


### PR DESCRIPTION
As the script greps from the output of a command, if the locale is not english, nothing works ¯\\\_(ツ)\_/¯