### PR TITLE
pkgdownload: runnable if no wget; readable if no terminal or no Unicode; a bit more tips for users; clean code

### DIFF
--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -26,7 +26,7 @@ function print_banner {
     echo "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+"
     echo "------------- Created by Wick3rman ------------"
     echo ""
-    tput setaf 7
+    tput sgr0
 }
 
 # prints a message with a given color.
@@ -121,11 +121,11 @@ function download_packages {
         if [[ $? -eq 0 ]]; then
             # Download success
             tput cuu1
-            echo "$(tput setaf 7)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${green} "[o]")"
+            echo "$(tput sgr0)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${green} "[o]")"
         else
             # Download failed
             tput cuu1
-            echo "$(tput setaf 7)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${red} "[x]")"
+            echo "$(tput sgr0)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${red} "[x]")"
         fi
     done < "$1"
 }
@@ -162,7 +162,7 @@ function get_dependencies {
 function get_global {
     # $1 package name
 
-    echo "$(tput setaf 7)[-] Found $gcount dependencies for:$(tput setaf 6) $1 $(tput setaf 7)"
+    echo "$(tput sgr0)[-] Found $gcount dependencies for:$(tput setaf 6) $1 $(tput sgr0)"
     # Store all dependencies to file.
     apt-cache depends $1 | grep -v "<" | grep -w "Depends:" > "$1_$filename"
     # Clean file from unnecessary characters.
@@ -219,7 +219,7 @@ if [[ $? -eq 0 ]]; then
         name="$line"
         # check if is package name
         if [[ $( echo ${name} | grep -v "<" | grep -icw "Depends:") -lt 1 ]]; then
-            #echo "[$] Round $round:$(tput setaf 6) $name $(tput setaf 7)"
+            #echo "[$] Round $round:$(tput setaf 6) $name $(tput sgr0)"
             pre=$(cat ${masterlist} | grep -ic "$name")
 
             #echo "Pret: $pre"

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -39,7 +39,7 @@ function printclr {
 }
 
 if [[ ${gcount} -eq 0 ]]; then
-    echo "[+] Verify the package name using '$(printclr ${cyan} "apt search")' and try again"
+    echo "[+] Re-synchronize the package index using '$(printclr ${cyan} "apt update")', verify the package name using '$(printclr ${cyan} "apt search")' and try again"
     exit
 fi
 

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -63,7 +63,7 @@ fi
 if [[ $? -ne 0 ]]; then
     # Exit code not 0
     echo "$(printclr ${red} "No connection, check your internet and try again")"
-    exit
+    exit 1
 fi
 
 # reset the timer
@@ -202,66 +202,67 @@ start_timer
 # create directory with package name
 mkdir "$package" &> /dev/null
 
-if [[ $? -eq 0 ]]; then
-    echo "$(printclr ${green} "[+] Created directory $(printclr ${cyan} "$package")")"
-    cd "$package"
-
-    # create masterlist file
-    touch ${masterlist}
-
-    # get dependencies for package and populate masterlist
-    get_global "$package"
-
-    # Sort and remove duplicates
-    echo "" >> ${fname}
-    sort *.list | uniq > ${fname}
-
-    # read the masterlist to get child dependencies
-    echo "[++] Checking for child dependencies"
-    while read -r line
-    do
-        name="$line"
-        # check if is package name
-        if [[ $( echo ${name} | grep -v "<" | grep -icw "Depends:") -lt 1 ]]; then
-            #echo "[$] Round $round: $(printclr "$cyan" $name)"
-            pre=$(cat ${masterlist} | grep -ic "$name")
-
-            #echo "Pret: $pre"
-            if [ ${pre} -eq 0 ]; then
-                get_dependencies ${name}
-                add_to_master_list ${name}
-            fi
-        fi
-        # it++
-        it=$(expr ${it} + 1)
-    done < "$fname"
-
-    # delete all list files
-    rm *.list
-
-    # download packages from masterlist
-    download_packages ${masterlist}
-
-    # delete *.deb.list file
-    rm ${fname}
-
-    # package downloaded packages in a Tarball
-    echo -n "[-] Packaging downloaded packages to $(printclr ${cyan} "$package.tar.gz")"
-    cd ..
-
-    # use tar to compress and package.
-    tar -zcvf "./$package.tar.gz" "$package/" &> /dev/null
-
-    # [Check] packaging success
-    check_if_successful $?
-
-    echo -n "[-] Removing original directory"
-    rm -r "./$package/"
-    # [Check] if directory was removed
-    check_if_successful $?
-
-    echo "$(printclr ${green} "[-] Operations completed in $(printclr ${yellow} "$(get_elapsed_time)")" )"
-else
+if [[ $? -ne 0 ]]; then
     echo "$(printclr ${red} "[!]")  Failed to create directory $(printclr ${cyan} "$package"). Delete existing directory or make sure you have sufficient permissions."
+    exit 1
 fi
+
+echo "$(printclr ${green} "[+] Created directory $(printclr ${cyan} "$package")")"
+cd "$package"
+
+# create masterlist file
+touch ${masterlist}
+
+# get dependencies for package and populate masterlist
+get_global "$package"
+
+# Sort and remove duplicates
+echo "" >> ${fname}
+sort *.list | uniq > ${fname}
+
+# read the masterlist to get child dependencies
+echo "[++] Checking for child dependencies"
+while read -r line
+do
+    name="$line"
+    # check if is package name
+    if [[ $( echo ${name} | grep -v "<" | grep -icw "Depends:") -lt 1 ]]; then
+        #echo "[$] Round $round: $(printclr "$cyan" $name)"
+        pre=$(cat ${masterlist} | grep -ic "$name")
+
+        #echo "Pret: $pre"
+        if [ ${pre} -eq 0 ]; then
+            get_dependencies ${name}
+            add_to_master_list ${name}
+        fi
+    fi
+    # it++
+    it=$(expr ${it} + 1)
+done < "$fname"
+
+# delete all list files
+rm *.list
+
+# download packages from masterlist
+download_packages ${masterlist}
+
+# delete *.deb.list file
+rm ${fname}
+
+# package downloaded packages in a Tarball
+echo -n "[-] Packaging downloaded packages to $(printclr ${cyan} "$package.tar.gz")"
+cd ..
+
+# use tar to compress and package.
+tar -zcvf "./$package.tar.gz" "$package/" &> /dev/null
+
+# [Check] packaging success
+check_if_successful $?
+
+echo -n "[-] Removing original directory"
+rm -r "./$package/"
+# [Check] if directory was removed
+check_if_successful $?
+
+echo "$(printclr ${green} "[-] Operations completed in $(printclr ${yellow} "$(get_elapsed_time)")" )"
 ### End main

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -18,24 +18,33 @@ black=0; red=1; green=2; yellow=3; blue=4; magenta=5; cyan=6; white=7;
 
 ### Start function declarations
 
+# prints a message with a given color if we are in a terminal.
+if [ -t 1 ]; then
+    function printclr {
+        # $1 - Color code
+        # $2 - Message
+        tput setaf $1
+        echo -ne "$2"
+        tput sgr0
+    };
+else
+    function printclr {
+        # $2 - Message
+        echo -ne "$2"
+    };
+fi
+
 # prints the banner
 function print_banner {
-    tput setaf 3
-    echo "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+"
-    echo "|  P a c k a g e  D o w n l o a d e r  v 1.4  |"
-    echo "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+"
-    echo "------------- Created by Wick3rman ------------"
+    printclr "$yellow" "$(cat <<- EOF
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	|  P a c k a g e  D o w n l o a d e r  v 1.4  |
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	------------- Created by Wick3rman ------------
+	EOF
+    )"
     echo ""
-    tput sgr0
-}
-
-# prints a message with a given color.
-function printclr {
-	# $1 - Color code
-	# $2 - Message
-    tput setaf $1
-    echo -ne "$2"
-    tput sgr0
+    echo ""
 }
 
 if [[ ${gcount} -eq 0 ]]; then
@@ -91,16 +100,13 @@ function add_to_master_list {
 # checks if the last command was successful
 function check_if_successful {
     # $1 - Command exit code
-    # $2 - Message
 
     if [[ $1 -eq 0 ]]; then
         # Command success
-        tput cuu1
-        echo "$2 $(printclr ${green} "[o]")"
+        echo " $(printclr ${green} "[o]")"
     else
         # Command failed
-        tput cuu1
-        echo "$2 $(printclr ${red} "[x]")"
+        echo " $(printclr ${red} "[x]")"
     fi
 }
 
@@ -115,17 +121,15 @@ function download_packages {
     while read -r line
     do
         name="$line"
-        echo "[-] Downloading: $(printclr ${cyan} "$name")"
+        echo -n "[-] Downloading: $(printclr ${cyan} "$name")"
         apt-get download "$name" &> /dev/null
 
         if [[ $? -eq 0 ]]; then
             # Download success
-            tput cuu1
-            echo "$(tput sgr0)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${green} "[o]")"
+            echo " $(printclr ${green} "[o]")"
         else
             # Download failed
-            tput cuu1
-            echo "$(tput sgr0)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${red} "[x]")"
+            echo " $(printclr ${red} "[x]")"
         fi
     done < "$1"
 }
@@ -162,7 +166,7 @@ function get_dependencies {
 function get_global {
     # $1 package name
 
-    echo "$(tput sgr0)[-] Found $gcount dependencies for:$(tput setaf 6) $1 $(tput sgr0)"
+    echo "[-] Found $gcount dependencies for: $(printclr ${cyan} "$1")"
     # Store all dependencies to file.
     apt-cache depends $1 | grep -v "<" | grep -w "Depends:" > "$1_$filename"
     # Clean file from unnecessary characters.
@@ -219,7 +223,7 @@ if [[ $? -eq 0 ]]; then
         name="$line"
         # check if is package name
         if [[ $( echo ${name} | grep -v "<" | grep -icw "Depends:") -lt 1 ]]; then
-            #echo "[$] Round $round:$(tput setaf 6) $name $(tput sgr0)"
+            #echo "[$] Round $round: $(printclr "$cyan" $name)"
             pre=$(cat ${masterlist} | grep -ic "$name")
 
             #echo "Pret: $pre"
@@ -242,19 +246,19 @@ if [[ $? -eq 0 ]]; then
     rm ${fname}
 
     # package downloaded packages in a Tarball
-    echo "[-] Packaging downloaded packages to $(printclr ${cyan} "$package.tar.gz")"
+    echo -n "[-] Packaging downloaded packages to $(printclr ${cyan} "$package.tar.gz")"
     cd ..
 
     # use tar to compress and package.
     tar -zcvf "./$package.tar.gz" "$package/" &> /dev/null
 
     # [Check] packaging success
-    check_if_successful $? "[-] Packaging downloaded packages to $(printclr ${cyan} "$package.tar.gz")"
+    check_if_successful $?
 
-    echo "[-] Removing original directory"
+    echo -n "[-] Removing original directory"
     rm -r "./$package/"
     # [Check] if directory was removed
-    check_if_successful $? "[-] Removing original directory "
+    check_if_successful $?
 
     echo "$(printclr ${green} "[-] Operations completed in $(printclr ${yellow} "$(get_elapsed_time)")" )"
 else

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -43,8 +43,14 @@ if [[ ${gcount} -eq 0 ]]; then
     exit
 fi
 
-# check for internet connectivity
-wget -q --tries=3 --timeout=3 --spider https://www.apple.com
+# check for internet connectivity if we have either wget or curl
+testurl="https://www.apple.com"
+
+if command -v wget &> /dev/null; then
+    wget -q --tries=3 --timeout=3 --spider "${testurl}"
+elif command -v curl &> /dev/null; then
+    curl -s -f --retry 3 --max-time 3 -o /dev/null "${testurl}"
+fi
 if [[ $? -ne 0 ]]; then
     # Exit code not 0
     echo "$(printclr ${red} "No connection, check your internet and try again")"

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -96,7 +96,7 @@ function check_if_successful {
     if [[ $1 -eq 0 ]]; then
         # Command success
         tput cuu1
-        echo "$2 $(printclr ${green} "[$(echo $'\u2714')]")"
+        echo "$2 $(printclr ${green} "[o]")"
     else
         # Command failed
         tput cuu1
@@ -121,7 +121,7 @@ function download_packages {
         if [[ $? -eq 0 ]]; then
             # Download success
             tput cuu1
-            echo "$(tput setaf 7)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${green} "[$(echo $'\u2714')]")"
+            echo "$(tput setaf 7)[-] Downloading: $(printclr ${cyan} "$name") $(printclr ${green} "[o]")"
         else
             # Download failed
             tput cuu1


### PR DESCRIPTION
Hello! I'm from your answer on unix.stackexchange.com [^1] . The `pkgdownload` script is a very useful tool. Thanks for your effort!

[^1]: [answer 472562 § How to download package not install it with apt-get command? - Unix & Linux Stack Exchange](https://unix.stackexchange.com/a/472562)

# Summary

I read your code and try improving it for the following points:

- Let the user run `apt update` before `apt search <package>` if error occurs.
- Use "curl" for the connectivity check if no "wget" found, or completely skip that check if we found neither "wget" nor "curl". 
- Make the output more readable during `docker build` or other non-terminal environment.
- Make the output string looks better in non-Unicode-supported environment.
- Make the script exit with non-zero code if error occurs.
- Clean and simplify the code.

Please read commit message of my commits for details.

Thank you!

# Comparison

![20241212-wickerscripts-pkgdownload-comparison](https://github.com/user-attachments/assets/cf8d87f7-e1c4-4990-aec5-ae7449dc3018)

# Test

## No "wget" found and non-terminal environment

Dockerfile:

```Dockerfile
FROM ubuntu:22.04

RUN apt update

COPY --chmod=775 ./pkgdownload /pkgdownload

RUN /pkgdownload python3-venv

```

During `docker build`:

```
#8 [4/4] RUN /pkgdownload python3-venv
#8 1.041 /pkgdownload: line 47: wget: command not found
#8 1.043 tput: No value for $TERM and no -T specified
#8 1.044 tput: No value for $TERM and no -T specified
#8 1.044 No connection, check your internet and try again
#8 DONE 1.1s

```

After applying my patches:

```
#8 [4/4] RUN /pkgdownload python3-venv
#8 1.012 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
#8 1.012 |  P a c k a g e  D o w n l o a d e r  v 1.4  |
#8 1.012 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
#8 1.012 ------------- Created by Wick3rman ------------
#8 1.012
#8 1.016 [+] Created directory python3-venv
#8 1.019 [-] Found 3 dependencies for: python3-venv
#8 1.856 [-] Added python3.10-venv to dependency list
#8 3.562 [-] Added ...
#8 17.15 [++] Checking for child dependencies
#8 18.89 [-] Added debconf to dependency list
#8 24.11 [-] Added ...
#8 24.14 [-] Downloading: python3.10-venv [o]
#8 25.49 [-] Downloading: ...
#8 79.14 [-] Packaging downloaded packages to python3-venv.tar.gz [o]
#8 79.37 [-] Removing original directory [o]
#8 79.38 [-] Operations completed in 1m 18s
#8 DONE 79.4s

```

## non-Unicode-supported environment

After installing "wget" and "ca-certificates", we can download packages:

```
#9 68.92 [-] Downloading: python3-venv [\u2714]
#9 68.92 tput: No value for $TERM and no -T specified
#9 68.92 tput: No value for $TERM and no -T specified
#9 68.92 [-] Packaging downloaded packages to python3-venv.tar.gz
#9 69.14 tput: No value for $TERM and no -T specified
#9 69.14 tput: No value for $TERM and no -T specified
#9 69.14 tput: No value for $TERM and no -T specified
#9 69.15 tput: No value for $TERM and no -T specified
#9 69.15 tput: No value for $TERM and no -T specified
#9 69.15 [-] Packaging downloaded packages to python3-venv.tar.gz [\u2714]
#9 69.15 [-] Removing original directory
#9 69.15 tput: No value for $TERM and no -T specified
#9 69.15 tput: No value for $TERM and no -T specified
#9 69.15 tput: No value for $TERM and no -T specified
#9 69.15 [-] Removing original directory  [\u2714]
#9 69.16 tput: No value for $TERM and no -T specified
#9 69.16 tput: No value for $TERM and no -T specified
#9 69.16 tput: No value for $TERM and no -T specified
#9 69.16 tput: No value for $TERM and no -T specified
#9 69.16 [-] Operations completed in 1m 8s
#9 DONE 69.2s

```

Please note these `[\u2714]` . To match the "x" char for errors, here I use the "o" char to replace `✔` (Tic-tac-toe).
