### PR TITLE
pkgdownload: fix dependency graph traversal for multiple-layer dependencies; simplify code

### DIFF
--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -8,8 +8,6 @@ fi
 
 package="$1"
 filename="deb.list"
-gcount=$(apt-cache depends ${package} | grep -v "<" | grep -icw "Depends:")
-it=0
 masterlist="dependencies_master_$RANDOM.mlist"
 
 # colors
@@ -37,7 +35,7 @@ function printclr {
     tput sgr0
 }
 
-if [[ ${gcount} -eq 0 ]]; then
+if [[ $(apt-cache depends ${package} | grep -v "<" | grep -icw "Depends:") -eq 0 ]]; then
     echo "[+] Verify the package name using '$(printclr ${cyan} "apt search")' and try again"
     exit
 fi
@@ -156,32 +154,8 @@ function get_dependencies {
 # gets dependencies for a package.
 function get_global {
     # $1 package name
-
-    echo "$(tput setaf 7)[-] Found $gcount dependencies for:$(tput setaf 6) $1 $(tput setaf 7)"
-    # Store all dependencies to file.
-    apt-cache depends $1 | grep -v "<" | grep -w "Depends:" > "$1_$filename"
-    # Clean file from unnecessary characters.
-    sed -i -e 's/[<>|:]//g' "$1_$filename"
-    sed -i -e 's/Depends//g' "$1_$filename"
-    sed -i -e 's/ //g' "$1_$filename"
-
-    while [ ${it} -lt ${gcount} ]
-    do
-        while read -r line
-        do
-            name="$line"
-            round=$(expr ${it} + 1)
-
-            if [[ $( echo ${name} | grep -v "<" | grep -c -w "Depends:") -lt 1 ]]; then
-                if [[ $(is_not_present "$name") -eq 0 ]]; then
-                    #echo "[-] Adding ${name} to masterlist"
-                    add_to_master_list ${name}
-                    get_dependencies ${name}
-                fi
-            fi
-            it=$(expr ${it} + 1)
-        done < "$1_$filename"
-    done
+    add_to_master_list "$1"
+    get_dependencies "$1"
 }
 
 ### End function declarations

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -69,7 +69,7 @@ function get_elapsed_time {
 # check if a dependency(package) is not present in the masterlist
 function is_not_present {
     # $1 package name
-    echo $(cat ${masterlist} | grep -ic "$1")
+    echo $(cat ${masterlist} | grep -Fxc "$1")
 }
 
 # add a dependecy(package) to the masterlist
@@ -214,7 +214,7 @@ if [[ $? -eq 0 ]]; then
         # check if is package name
         if [[ $( echo ${name} | grep -v "<" | grep -icw "Depends:") -lt 1 ]]; then
             #echo "[$] Round $round:$(tput setaf 6) $name $(tput setaf 7)"
-            pre=$(cat ${masterlist} | grep -ic "$name")
+            pre=$(is_not_present "$name")
 
             #echo "Pret: $pre"
             if [ ${pre} -eq 0 ]; then

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -8,7 +8,6 @@ fi
 
 package="$1"
 filename="deb.list"
-fname="complete_deb.txt"
 gcount=$(apt-cache depends ${package} | grep -v "<" | grep -icw "Depends:")
 it=0
 masterlist="dependencies_master_$RANDOM.mlist"
@@ -204,38 +203,11 @@ if [[ $? -eq 0 ]]; then
     # get dependencies for package and populate masterlist
     get_global "$package"
 
-    # Sort and remove duplicates
-    echo "" >> ${fname}
-    sort *.list | uniq > ${fname}
-
-    # read the masterlist to get child dependencies
-    echo "[++] Checking for child dependencies"
-    while read -r line
-    do
-        name="$line"
-        # check if is package name
-        if [[ $( echo ${name} | grep -v "<" | grep -icw "Depends:") -lt 1 ]]; then
-            #echo "[$] Round $round:$(tput setaf 6) $name $(tput setaf 7)"
-            pre=$(is_not_present "$name")
-
-            #echo "Pret: $pre"
-            if [ ${pre} -eq 0 ]; then
-                get_dependencies ${name}
-                add_to_master_list ${name}
-            fi
-        fi
-        # it++
-        it=$(expr ${it} + 1)
-    done < "$fname"
-
     # delete all list files
     rm *.list
 
     # download packages from masterlist
     download_packages ${masterlist}
-
-    # delete *.deb.list file
-    rm ${fname}
 
     # package downloaded packages in a Tarball
     echo "[-] Packaging downloaded packages to $(printclr ${cyan} "$package.tar.gz")"

--- a/Shell/pkgdownload
+++ b/Shell/pkgdownload
@@ -135,6 +135,8 @@ function get_dependencies {
     sed -i -e 's/ //g' "${p1}_${filename}"
 
     # Local count
+    local lcount
+    local lit
     lcount=$(apt-cache depends ${p1} | grep -v "<" | grep -icw "Depends:")
     lit=0
 


### PR DESCRIPTION
Hi.

This script cannot find all dependencies of some packages. For example, on Ubuntu 22.04 (Jammy), to find "libexpat1" from "python3-venv", there are two routes:

- Route 1
  - python3-venv
  - python3
  - python3.10
  - python3.10-minimal
  - libexpat1
- Route 2
  - python3-venv
  - python3
  - python3-minimal
  - python3.10-minimal
  - libexpat1

Before this PR:

```console
# ./pkgdownload.72433e1ee1b5b8eeca78830be3bf8478813dc445 'python3-venv'
...
[+] Created directory python3-venv
[-] Found 3 dependencies for: python3-venv
[-] Added python3.10-venv to dependency list
[-] Added python3-pip-whl to dependency list
[-] Added ca-certificates to dependency list
[-] Added openssl to dependency list
[-] Added libc6 to dependency list
[-] Added libgcc-s1 to dependency list
[-] Added gcc-12-base to dependency list
[-] Added python3-distutils to dependency list
[-] Added python3-lib2to3 to dependency list
[++] Checking for child dependencies
[-] Added debconf to dependency list
[-] Added python3-setuptools-whl to dependency list
[-] Downloading: ...

```

After applying the 1st commit (984e417b26f7a4b268cdaaf676c3808614a79ab4):

```console
# ./pkgdownload.984e417b26f7a4b268cdaaf676c3808614a79ab4 'python3-venv'
...
[+] Created directory python3-venv
[-] Found 3 dependencies for: python3-venv
[-] Added python3.10-venv to dependency list
[-] Added python3.10 to dependency list
[-] Added python3.10-minimal to dependency list
[-] Added libpython3.10-minimal to dependency list
[-] Added libc6 to dependency list
[-] Added libgcc-s1 to dependency list
[-] Added gcc-12-base to dependency list
[-] Added python3 to dependency list
[-] Added libpython3-stdlib to dependency list
[-] Added libpython3.10-stdlib to dependency list
[-] Added media-types to dependency list
[-] Added python3-distutils to dependency list
[-] Added python3-lib2to3 to dependency list
[++] Checking for child dependencies
[-] Added libstdc++6 to dependency list
[-] Added libtinfo6 to dependency list
[-] Added libtirpc3 to dependency list
[-] Added libgssapi-krb5-2 to dependency list
[-] Added libcom-err2 to dependency list
[-] Added readline-common to dependency list
[-] Added dpkg to dependency list
[-] Added tar to dependency list
[-] Added debconf to dependency list
[-] Added mailcap to dependency list
[-] Added perl to dependency list
[-] Added perl-base to dependency list
[-] Added ca-certificates to dependency list
[-] Added openssl to dependency list
[-] Added libssl3 to dependency list
[-] Added python3-setuptools-whl to dependency list
[-] Downloading: ...

```

After applying the 2nd commit (4125cc88a1a614979607b9d28bf89c678dcab69e):

```console
# ./pkgdownload.4125cc88a1a614979607b9d28bf89c678dcab69e 'python3-venv'
...
[+] Created directory python3-venv
[-] Found 3 dependencies for: python3-venv
[-] Added python3.10-venv to dependency list
[-] Added python3.10 to dependency list
[-] Added python3.10-minimal to dependency list
[-] Added libpython3.10-minimal to dependency list
[-] Added libc6 to dependency list
[-] Added libgcc-s1 to dependency list
[-] Added gcc-12-base to dependency list
[-] Added libcrypt1 to dependency list
[-] Added libssl3 to dependency list
[-] Added debconf to dependency list
[-] Added libexpat1 to dependency list
[-] Added zlib1g to dependency list
[-] Added libpython3.10-stdlib to dependency list
[-] Added media-types to dependency list
[-] Added mime-support to dependency list
[-] Added mailcap to dependency list
[-] Added perl to dependency list
[-] Added perl-base to dependency list
[-] Added perl-modules-5.34 to dependency list
[-] Added libperl5.34 to dependency list
[-] Added libbz2-1.0 to dependency list
[-] Added libdb5.3 to dependency list
[-] Added libgdbm-compat4 to dependency list
[-] Added libgdbm6 to dependency list
[-] Added libffi8 to dependency list
[-] Added liblzma5 to dependency list
[-] Added libmpdec3 to dependency list
[-] Added libstdc++6 to dependency list
[-] Added libncursesw6 to dependency list
[-] Added libtinfo6 to dependency list
[-] Added libnsl2 to dependency list
[-] Added libtirpc3 to dependency list
[-] Added libgssapi-krb5-2 to dependency list
[-] Added libcom-err2 to dependency list
[-] Added libk5crypto3 to dependency list
[-] Added libkrb5support0 to dependency list
[-] Added libkrb5-3 to dependency list
[-] Added libkeyutils1 to dependency list
[-] Added libtirpc-common to dependency list
[-] Added libreadline8 to dependency list
[-] Added readline-common to dependency list
[-] Added dpkg to dependency list
[-] Added tar to dependency list
[-] Added install-info to dependency list
[-] Added libsqlite3-0 to dependency list
[-] Added libuuid1 to dependency list
[-] Added python3-pip-whl to dependency list
[-] Added ca-certificates to dependency list
[-] Added openssl to dependency list
[-] Added python3-setuptools-whl to dependency list
[-] Added python3 to dependency list
[-] Added libpython3-stdlib to dependency list
[-] Added python3-distutils to dependency list
[-] Added python3-lib2to3 to dependency list
[++] Checking for child dependencies
[-] Downloading: ...

```

After applying the 3rd commit (cf173448ce1c95ccb4906f2b75688de3b21d0d9a), the `[++] Checking for child dependencies` line has been removed.

After applying the 4th commit (84c350bc20ea0bcb5f6060a7d3bdf7b778dbfbec):

```diff
  [+] Created directory python3-venv
- [-] Found 3 dependencies for: python3-venv
+ [-] Added python3-venv to dependency list
  [-] Added python3.10-venv to dependency list

```

All changes are made by Copilot, and I've tested all commits in official Ubuntu 22.04 Docker container.
